### PR TITLE
Various improvements

### DIFF
--- a/rubytextview/build.gradle
+++ b/rubytextview/build.gradle
@@ -6,7 +6,7 @@ android {
 
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 15
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"

--- a/rubytextview/src/main/java/me/weilunli/views/RubyTextView.java
+++ b/rubytextview/src/main/java/me/weilunli/views/RubyTextView.java
@@ -105,9 +105,12 @@ public class RubyTextView extends AppCompatTextView {
         int width = MeasureSpec.getSize(widthMeasureSpec);
         float cur_x = 0;
         int lineCount = 1;
+        float maxwidth = 0;
 
         for(String[] t : combinedTextArray) {
             float textWidth = textPaint.measureText(t[0]);
+            float rubyWidth = rubyTextPaint.measureText(t[1]);
+            float elementWidth = Math.max(textWidth, rubyWidth);
 
             // if t[0] == '\n'
             if(t[0].equals(System.getProperty("line.separator"))){
@@ -116,18 +119,20 @@ public class RubyTextView extends AppCompatTextView {
                 continue;
             }
 
-            if (cur_x + textWidth > width){
+            if (cur_x + elementWidth > width){
                 cur_x = 0;
                 lineCount++;
             }
 
-            cur_x += textWidth;
+            cur_x += elementWidth;
+            if(cur_x > maxwidth)
+                maxwidth = cur_x;
         }
 
         // total height
         int height = getMySize(heightMeasureSpec,
                 (int) (firstLineheight + lineheight * (lineCount-1)) + getLastBaselineToBottomHeight());
-        setMeasuredDimension(MeasureSpec.getSize(widthMeasureSpec), height);
+        setMeasuredDimension((int) maxwidth, height);
     }
 
     @Override
@@ -140,6 +145,8 @@ public class RubyTextView extends AppCompatTextView {
              * Draw text *
              * ***********/
             float textWidth = textPaint.measureText(t[0]);
+            float rubyWidth = rubyTextPaint.measureText(t[1]);
+            float elementWidth = Math.max(textWidth, rubyWidth);
 
             if(t[0].equals(System.getProperty("line.separator"))){
                 cur_x = 0;
@@ -153,17 +160,17 @@ public class RubyTextView extends AppCompatTextView {
                 if(isFirstLine) isFirstLine = false;
                 cur_y += lineheight;
             }
-            canvas.drawText(t[0], cur_x, cur_y, textPaint);
+            float text_posX = cur_x + (1 / 2f) * (elementWidth - textWidth);
+            canvas.drawText(t[0], text_posX, cur_y, textPaint);
 
             /* ****************
              * Draw ruby text *
              * ****************/
-            float rubyText_posX = cur_x +
-                    (1 / 2f) * (textWidth - rubyTextPaint.measureText(t[1]));
+            float rubyText_posX = cur_x + (1 / 2f) * (elementWidth - rubyWidth);
             canvas.drawText(t[1], rubyText_posX, cur_y - getTextSize() - getSpacing(), rubyTextPaint);
 
             // update cur_x position
-            cur_x += textWidth;
+            cur_x += elementWidth;
         }
     }
 

--- a/rubytextview/src/main/java/me/weilunli/views/RubyTextView.java
+++ b/rubytextview/src/main/java/me/weilunli/views/RubyTextView.java
@@ -237,6 +237,9 @@ public class RubyTextView extends AppCompatTextView {
     public void splitCombinedText() {
         combinedTextArray.clear();
         originalText.setLength(0);
+        if(getCombinedText() == null)
+            return;
+
         String[] split = getCombinedText().split(" ");
         for (String value : split) {
             String[] t = value.split("\\|");

--- a/rubytextview/src/main/java/me/weilunli/views/RubyTextView.java
+++ b/rubytextview/src/main/java/me/weilunli/views/RubyTextView.java
@@ -9,7 +9,6 @@ import android.util.AttributeSet;
 import android.util.TypedValue;
 
 import androidx.appcompat.widget.AppCompatTextView;
-import androidx.core.content.ContextCompat;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,8 +45,7 @@ public class RubyTextView extends AppCompatTextView {
         try {
             combinedText = ta.getString(R.styleable.RubyTextView_combinedText);
             rubyTextSize = ta.getDimension(R.styleable.RubyTextView_rubyTextSize, 28f);
-            rubyTextColor = ta.getColor(R.styleable.RubyTextView_rubyTextColor,
-                    ContextCompat.getColor(getContext(), R.color.black));
+            rubyTextColor = ta.getColor(R.styleable.RubyTextView_rubyTextColor, rubyTextColor);
             spacing = ta.getDimension(R.styleable.RubyTextView_spacing, 0);
             lineSpacingExtra = ta.getDimension(R.styleable.RubyTextView_lineSpacingExtra, 0);
 

--- a/rubytextview/src/main/java/me/weilunli/views/RubyTextView.java
+++ b/rubytextview/src/main/java/me/weilunli/views/RubyTextView.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Canvas;
 import android.graphics.Paint;
+import android.os.Build;
 import android.util.AttributeSet;
 import android.util.TypedValue;
 
@@ -21,6 +22,7 @@ public class RubyTextView extends AppCompatTextView {
     private float rubyTextSize= 28f;
     private int rubyTextColor ;
     private float spacing = 0f;
+    private float lineSpacingExtra = 0f;
 
     // Need to address first line because it don't need extra spacing.
     private float lineheight = 0;
@@ -47,6 +49,7 @@ public class RubyTextView extends AppCompatTextView {
             rubyTextColor = ta.getColor(R.styleable.RubyTextView_rubyTextColor,
                     ContextCompat.getColor(getContext(), R.color.black));
             spacing = ta.getDimension(R.styleable.RubyTextView_spacing, 0);
+            lineSpacingExtra = ta.getDimension(R.styleable.RubyTextView_lineSpacingExtra, 0);
 
         } finally {
             ta.recycle();
@@ -73,6 +76,13 @@ public class RubyTextView extends AppCompatTextView {
         firstLineheight = lineheight - getLineSpacingExtra();
         splitCombinedText();
         setLineHeight((int) lineheight);
+    }
+
+    public float getLineSpacingExtra() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            return super.getLineSpacingExtra();
+        }
+        return lineSpacingExtra;
     }
 
 

--- a/rubytextview/src/main/res/values/colors.xml
+++ b/rubytextview/src/main/res/values/colors.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <color name="black">#000</color>
-</resources>


### PR DESCRIPTION
Hi!

I've started using your RubyTextView recently and found a few issues that I fixed in this PR. First, my app used to target API 15 and above, but your library targets 21 or above. There's really no reason why it can't target 16, and the first commit ensures it can even target 15 like my app (lineSpacingExtra was added in 16).

Then, I set the text programmatically, not statically in the XML, which lead to a crash which I fixed in the second commit.

I also use a dark theme, so the hard-coded black color for the ruby text was almost not visible. Instead, the third patch replaces it to default to the default text color, just like the rest of the text.

Finally, I had a few issues with measurement and the way the text was painted. First, I needed to use the widget with `width="wrapContent"`, but the measurement always returns the parent size, so the widget took all the space, leaving no space for the rest of my layout on the right. I fixed that by returning instead the width of the largest line. I also have some furigana that exceeds the size of the kanji it is related to, and this presents two issues: it can overflow on the left and be hidden, and it can be overwritten by the next furigana block. I fixed that by creating additional spacing between text blocks when the ruby text is longer than the text it is related to.